### PR TITLE
Fix copy/paste error in docs

### DIFF
--- a/samples/KubernetesIngress.Sample/README.md
+++ b/samples/KubernetesIngress.Sample/README.md
@@ -81,7 +81,7 @@ See https://microsoft.github.io/reverse-proxy/articles/authn-authz.html for a li
 
 Specifies the protocol of the backend service. Defaults to http.
 
-`yarp.ingress.kubernetes.io/authorization-policy: "https"`
+`yarp.ingress.kubernetes.io/backend-protocol: "https"`
 
 #### CORS Policy
 


### PR DESCRIPTION
Looks like a copy/paste error in the docs for the yarp.ingress.kubernetes.io/backend-protocol annotation